### PR TITLE
User callbacks for send failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "macros",
     "examples/paxos",
     "examples/ping_pong",
-    "examples/read_write_server", "examples/paxos",
+    "examples/read_write_server",
     "examples/ab",
 ]
 

--- a/actor/src/codec.rs
+++ b/actor/src/codec.rs
@@ -72,7 +72,6 @@ impl<M> From<std::io::Error> for EncodeError<M> {
 }
 
 impl<E: bincode::Encode, D> tokio_util::codec::Encoder<E> for BincodeCodec<E, D> {
-    // type Error = std::io::Error;
     type Error = EncodeError<E>;
     fn encode(&mut self, item: E, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let encoded_data = bincode::encode_to_vec(&item, self.config).map_err(|_| {
@@ -90,19 +89,6 @@ impl<E: bincode::Encode, D> tokio_util::codec::Encoder<E> for BincodeCodec<E, D>
         Ok(())
     }
 }
-// EncodeError {
-//     io_error:
-//     std::io::Error::new(
-//         std::io::ErrorKind::InvalidData,
-//         "Couldn't encode length-delimited data",
-//     ),
-//     msg: item,
-// }
-
-// std::io::Error::new(
-//     std::io::ErrorKind::InvalidData,
-//     EncodeErrorPayload{error_string: "Couldn't encode length-delimited data".to_string(), msg: item},
-// )
 
 #[derive(Clone)]
 pub struct BincodeSubdecoder<D, MD> {

--- a/actor/src/codec.rs
+++ b/actor/src/codec.rs
@@ -47,23 +47,62 @@ impl<E, D: bincode::Decode<()>> tokio_util::codec::Decoder for BincodeCodec<E, D
     }
 }
 
+pub struct EncodeError<M> {
+    pub io_error: std::io::Error,
+    pub msg: Option<M>,
+}
+
+pub trait ErrWithMsg<M> {
+    fn into_inner(self) -> Option<M>;
+}
+
+impl<M> ErrWithMsg<M> for EncodeError<M> {
+    fn into_inner(self) -> Option<M> {
+        self.msg
+    }
+}
+
+impl<M> From<std::io::Error> for EncodeError<M> {
+    fn from(err: std::io::Error) -> Self {
+        EncodeError {
+            io_error: err,
+            msg: None,
+        }
+    }
+}
+
 impl<E: bincode::Encode, D> tokio_util::codec::Encoder<E> for BincodeCodec<E, D> {
-    type Error = std::io::Error;
+    // type Error = std::io::Error;
+    type Error = EncodeError<E>;
     fn encode(&mut self, item: E, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let encoded_data = bincode::encode_to_vec(&item, self.config).map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::InvalidData, "Failed to encode data")
         })?;
         self.length_codec
             .encode(Bytes::from(encoded_data), dst)
-            .map_err(|_| {
-                std::io::Error::new(
+            .map_err(|_| EncodeError {
+                io_error: std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     "Couldn't encode length-delimited data",
-                )
+                ),
+                msg: Some(item),
             })?;
         Ok(())
     }
 }
+// EncodeError {
+//     io_error:
+//     std::io::Error::new(
+//         std::io::ErrorKind::InvalidData,
+//         "Couldn't encode length-delimited data",
+//     ),
+//     msg: item,
+// }
+
+// std::io::Error::new(
+//     std::io::ErrorKind::InvalidData,
+//     EncodeErrorPayload{error_string: "Couldn't encode length-delimited data".to_string(), msg: item},
+// )
 
 #[derive(Clone)]
 pub struct BincodeSubdecoder<D, MD> {

--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -28,6 +28,8 @@ pub use node_comm::{Connection, ControlInst, ControlReq, NodeComm};
 pub use reactor_channel::{HasPriority, MAX_PRIO};
 pub use reactor_macros::actor;
 
+use crate::codec::ErrWithMsg;
+
 pub type ActorSpawnCB = fn(RuntimeCtx, HashMap<String, serde_json::Value>);
 
 pub struct ExportedFn {
@@ -332,10 +334,18 @@ impl<M: Msg> ActorSend for NoOpActorSend<M> {
     }
 }
 
+/// Defines the action to take when sending a message fails. Variants:
+/// - Drop: drops the message.
+/// - Retry: retries sending the message, with parameters:
+///   - attempts: maximum number of retry attempts (None for infinite retries).
+///   - delay_ms: delay in milliseconds between retry attempts.
 #[derive(Copy, Clone, Debug)]
 pub enum SendErrAction {
     Drop,
-    Retry(Option<u32>),
+    Retry {
+        attempts: Option<u16>,
+        delay_ms: u64,
+    },
 }
 
 /// The `Behaviour` struct encapsulates the complete behavior of an actor,
@@ -355,6 +365,7 @@ pub enum SendErrAction {
 /// - `proc`: The core processing logic implementing `ActorProcess`.
 /// - `send`: Optional sender logic implementing `ActorSend`.
 /// - `generators`: A list of internal message generators, producing messages of type `M`.
+/// - `on_send_failure`: Action to take when sending a message fails. Defaults to retrying 5 times with 100ms delay.
 ///
 pub struct Behaviour<R, P, S, M: 'static, MCD> {
     recv: Option<R>,
@@ -400,7 +411,10 @@ impl<P, IM, OM, MCD> BehaviourBuilder<NoOpActorRecv<IM>, P, NoOpActorSend<OM>, I
             master_codec,
             sub_decoders: None,
             ask_recver_to_adapt: false,
-            on_send_failure: SendErrAction::Drop,
+            on_send_failure: SendErrAction::Retry {
+                attempts: Some(5),
+                delay_ms: 100,
+            },
         }
     }
 }
@@ -537,7 +551,7 @@ where
     P: ActorProcess<IMsg = IM, OMsg = OM>,
     S: ActorSend<OMsg = OM>,
     MCD: Encoder<OM> + Decoder<Item = IM, Error = std::io::Error> + Send + Sync + Clone + 'static,
-    <MCD as Encoder<OM>>::Error: Send + 'static,
+    <MCD as Encoder<OM>>::Error: Send + 'static + ErrWithMsg<OM>,
 {
     pub async fn run(mut self, ctx: RuntimeCtx) -> Result<(), ActorError> {
         // let my_addr = ctx.addr.to_string();

--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -332,6 +332,12 @@ impl<M: Msg> ActorSend for NoOpActorSend<M> {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum SendErrAction {
+    Drop,
+    Retry(Option<u32>),
+}
+
 /// The `Behaviour` struct encapsulates the complete behavior of an actor,
 /// including how it receives messages, processes them, sends output,
 /// and optionally generates new messages.
@@ -359,6 +365,7 @@ pub struct Behaviour<R, P, S, M: 'static, MCD> {
     master_codec: MCD,
     sub_decoders: Option<SubDecoderStore<M>>,
     receiver_should_adapt: bool,
+    on_send_failure: SendErrAction,
 }
 
 pub struct DecoderProvider<M> {
@@ -378,6 +385,7 @@ pub struct BehaviourBuilder<R, P, S, IM: 'static, OM, MCD> {
     sub_decoders: Option<SubDecoderStore<IM>>,
     ask_recver_to_adapt: bool,
     m: PhantomData<OM>,
+    on_send_failure: SendErrAction,
 }
 
 impl<P, IM, OM, MCD> BehaviourBuilder<NoOpActorRecv<IM>, P, NoOpActorSend<OM>, IM, OM, MCD> {
@@ -392,6 +400,7 @@ impl<P, IM, OM, MCD> BehaviourBuilder<NoOpActorRecv<IM>, P, NoOpActorSend<OM>, I
             master_codec,
             sub_decoders: None,
             ask_recver_to_adapt: false,
+            on_send_failure: SendErrAction::Drop,
         }
     }
 }
@@ -411,6 +420,7 @@ impl<R, P, S, IM, OM, MCD> BehaviourBuilder<R, P, S, IM, OM, MCD> {
             master_codec: self.master_codec,
             sub_decoders: self.sub_decoders,
             ask_recver_to_adapt: self.ask_recver_to_adapt,
+            on_send_failure: self.on_send_failure,
         }
     }
     pub fn send<S1>(self, send: S1) -> BehaviourBuilder<R, P, S1, IM, OM, MCD>
@@ -427,6 +437,7 @@ impl<R, P, S, IM, OM, MCD> BehaviourBuilder<R, P, S, IM, OM, MCD> {
             master_codec: self.master_codec,
             sub_decoders: self.sub_decoders,
             ask_recver_to_adapt: self.ask_recver_to_adapt,
+            on_send_failure: self.on_send_failure,
         }
     }
 
@@ -471,6 +482,14 @@ impl<R, P, S, IM, OM, MCD> BehaviourBuilder<R, P, S, IM, OM, MCD> {
         self
     }
 
+    pub fn on_send_failure(
+        mut self,
+        action: SendErrAction,
+    ) -> BehaviourBuilder<R, P, S, IM, OM, MCD> {
+        self.on_send_failure = action;
+        self
+    }
+
     pub fn build(self) -> Behaviour<R, P, S, IM, MCD> {
         Behaviour {
             recv: self.recv,
@@ -481,6 +500,7 @@ impl<R, P, S, IM, OM, MCD> BehaviourBuilder<R, P, S, IM, OM, MCD> {
             master_codec: self.master_codec,
             sub_decoders: self.sub_decoders,
             receiver_should_adapt: self.ask_recver_to_adapt,
+            on_send_failure: self.on_send_failure,
         }
     }
 }
@@ -517,6 +537,7 @@ where
     P: ActorProcess<IMsg = IM, OMsg = OM>,
     S: ActorSend<OMsg = OM>,
     MCD: Encoder<OM> + Decoder<Item = IM, Error = std::io::Error> + Send + Sync + Clone + 'static,
+    <MCD as Encoder<OM>>::Error: Send + 'static,
 {
     pub async fn run(mut self, ctx: RuntimeCtx) -> Result<(), ActorError> {
         // let my_addr = ctx.addr.to_string();
@@ -630,6 +651,7 @@ where
             p2s_rx,
             controller_tx,
             self.master_codec,
+            self.on_send_failure,
         ));
         rx_handle.await??;
         proc_handle.await??;

--- a/actor/src/send.rs
+++ b/actor/src/send.rs
@@ -11,6 +11,7 @@ use tokio_util::codec::{Encoder, FramedWrite};
 
 use crate::{
     ActorAddr, ActorSend, Msg, RouteTo, SendErrAction,
+    codec::ErrWithMsg,
     node_comm::{Connection, ControlReq},
 };
 
@@ -27,7 +28,7 @@ pub(crate) async fn tx<M, E, BS>(
     M: Msg,
     BS: ActorSend<OMsg = M>,
     E: Encoder<M> + 'static + Send + Clone,
-    E::Error: Send + 'static, // <-- add this line
+    E::Error: Send + 'static + ErrWithMsg<M>,
 {
     let mut addr_to_buff: HashMap<ActorAddr, mpsc::UnboundedSender<M>> = HashMap::new();
     let mut sub_senders = JoinSet::new();
@@ -114,7 +115,7 @@ fn send_msg<M, E>(
 ) where
     M: Msg,
     E: Encoder<M> + 'static + Send + Clone,
-    E::Error: Send + 'static,
+    E::Error: Send + 'static + ErrWithMsg<M>,
 {
     if let Some(sender) = addr_to_buff.get(addr) {
         if let Err(e) = sender.send(m) {
@@ -147,9 +148,9 @@ async fn sender_task<M, E>(
 ) where
     M: Msg,
     E: Encoder<M> + 'static + Send,
-    E::Error: Send + 'static,
+    E::Error: Send + 'static + ErrWithMsg<M>,
 {
-    async fn remote_sender<C: Encoder<M> + 'static + Send, M>(
+    async fn remote_sender<C, M>(
         my_addr: &'static str,
         ask_receiver_to_adapt: bool,
         mut tx: impl AsyncWrite + Unpin,
@@ -158,6 +159,8 @@ async fn sender_task<M, E>(
         on_send_failure: SendErrAction,
     ) where
         M: Msg,
+        C::Error: Send + 'static + ErrWithMsg<M>,
+        C: Encoder<M> + 'static + Send,
     {
         log::info!("[ACTOR] SubTx Started");
         let decoder_name = std::any::type_name::<M>().to_string();
@@ -165,33 +168,41 @@ async fn sender_task<M, E>(
         let mut framed_writer = FramedWrite::new(tx, encoder);
 
         while let Some(msg) = rx.recv().await {
+            let Err(e) = framed_writer.send(msg).await else {
+                continue;
+            };
+            let mut failed_msg = e.into_inner().unwrap();
             match on_send_failure {
                 SendErrAction::Drop => {
-                    if (framed_writer.send(msg).await).is_err() {
-                        log::warn!("[ACTOR] {} Dropping message due to send failure", my_addr);
-                    }
+                    log::warn!("[ACTOR] {} Failed to send message, dropping", my_addr);
                 }
-                SendErrAction::Retry(retries_opt) => {
+                SendErrAction::Retry {
+                    attempts: retries_opt,
+                    delay_ms,
+                } => {
                     let mut attempts = 0;
                     loop {
                         if let Some(retries) = retries_opt
                             && attempts >= retries
                         {
-                            log::error!("[ACTOR] {} Exhausted retries to send message", my_addr);
+                            log::error!(
+                                "[ACTOR] {} Failed to send message, retries exhausted",
+                                my_addr
+                            );
                             break;
                         }
 
                         attempts += 1;
 
-                        // Note: here the below clone happens even for successful sends, causing inefficiency
-                        // But how can we know beforehand if the send will succeed or not?
-                        if (framed_writer.send(msg.clone()).await).is_err() {
+                        if let Err(err_msg) = framed_writer.send(failed_msg).await {
+                            failed_msg = err_msg.into_inner().unwrap();
+
                             log::warn!(
-                                "[ACTOR] {} Failed to send message, Retrying {}",
+                                "[ACTOR] {} Failed to send message, retries: {}",
                                 my_addr,
                                 attempts
                             );
-                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                             continue;
                         } else {
                             break;
@@ -218,28 +229,25 @@ async fn sender_task<M, E>(
         let decoder_name = std::any::type_name::<M>().to_string();
         send_local_handshake(&tx, my_addr, decoder_name, ask_receiver_to_adapt).await;
         while let Some(msg) = rx.recv().await {
-            // if let Err(e) = tx.send(Box::new(msg)).await {
-            //     log::error!("[ACTOR] Failed to send local message: {}", e);
-            //     break;
-            // }
+            let Err(e) = tx.send(Box::new(msg)).await else {
+                continue;
+            };
+            let mut failed_msg: M = *e.0.downcast::<M>().unwrap();
             match on_send_failure {
                 SendErrAction::Drop => {
-                    if let Err(e) = tx.send(Box::new(msg)).await {
-                        log::warn!(
-                            "[ACTOR] {} Dropping message due to send failure: {}",
-                            my_addr,
-                            e
-                        );
-                    }
+                    log::warn!("[ACTOR] {} Failed to send message, dropping", my_addr);
                 }
-                SendErrAction::Retry(retries_opt) => {
+                SendErrAction::Retry {
+                    attempts: retries_opt,
+                    delay_ms,
+                } => {
                     let mut attempts = 0;
                     loop {
                         if let Some(retries) = retries_opt
                             && attempts >= retries
                         {
                             log::error!(
-                                "[ACTOR] {} Exhausted retries to send local message",
+                                "[ACTOR] {} Failed to send message, retries exhausted",
                                 my_addr
                             );
                             break;
@@ -247,16 +255,14 @@ async fn sender_task<M, E>(
 
                         attempts += 1;
 
-                        // Note: here the below clone happens even for successful sends, causing inefficiency
-                        // But how can we know beforehand if the send will succeed or not?
-                        if let Err(e) = tx.send(Box::new(msg.clone())).await {
+                        if let Err(e) = tx.send(Box::new(failed_msg)).await {
+                            failed_msg = *e.0.downcast::<M>().unwrap();
                             log::warn!(
-                                "[ACTOR] {} Failed to send message, Retrying {}: {}",
+                                "[ACTOR] {} Failed to send message, retries: {}",
                                 my_addr,
                                 attempts,
-                                e
                             );
-                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                             continue;
                         } else {
                             break;
@@ -268,13 +274,14 @@ async fn sender_task<M, E>(
         log::info!("[ACTOR] SubTx Ended");
     }
 
+    let mut attempts = 0;
     loop {
         let (c_tx, c_rx) = tokio::sync::oneshot::channel();
         log::debug!("[ACTOR] Sending Resolve request for address: {}", send_addr);
         controller_tx
             .send(ControlReq::Resolve {
                 resp_tx: c_tx,
-                addr: send_addr.clone(), // to satisfy borrow checker, is it necessary?
+                addr: send_addr.clone(),
             })
             .await
             .unwrap();
@@ -316,25 +323,39 @@ async fn sender_task<M, E>(
                 .await;
                 break;
             }
-            Connection::CouldntResolve => {
-                log::warn!("[ACTOR] Failed to resolve {}", send_addr);
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                match on_send_failure {
-                    SendErrAction::Drop => break,
-                    SendErrAction::Retry(retries_opt) => {
-                        if let Some(retries) = retries_opt
-                            && retries == 0
-                        {
-                            log::error!(
-                                "[ACTOR] {} Exhausted retries to resolve address {}",
-                                my_addr,
-                                send_addr
-                            );
-                            break;
-                        }
-                    }
+            Connection::CouldntResolve => match on_send_failure {
+                SendErrAction::Drop => {
+                    log::warn!(
+                        "[ACTOR] {} Failed to resolve {}, dropping",
+                        my_addr,
+                        send_addr
+                    );
+                    break;
                 }
-            }
+                SendErrAction::Retry {
+                    attempts: retries_opt,
+                    delay_ms,
+                } => {
+                    if let Some(retries) = retries_opt
+                        && attempts >= retries
+                    {
+                        log::error!(
+                            "[ACTOR] {} Failed to resolve {}, retries exhausted",
+                            my_addr,
+                            send_addr
+                        );
+                        break;
+                    }
+                    attempts += 1;
+                    log::warn!(
+                        "[ACTOR] {} Failed to resolve {}, retrying {}",
+                        my_addr,
+                        send_addr,
+                        attempts,
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+            },
         };
     }
 }

--- a/actor/src/send.rs
+++ b/actor/src/send.rs
@@ -10,7 +10,7 @@ use tokio::{
 use tokio_util::codec::{Encoder, FramedWrite};
 
 use crate::{
-    ActorAddr, ActorSend, Msg, RouteTo,
+    ActorAddr, ActorSend, Msg, RouteTo, SendErrAction,
     node_comm::{Connection, ControlReq},
 };
 
@@ -22,10 +22,12 @@ pub(crate) async fn tx<M, E, BS>(
     mut p_rx: mpsc::UnboundedReceiver<(M, &'static str)>,
     controller_tx: mpsc::Sender<ControlReq>,
     codec: E,
+    on_send_failure: SendErrAction,
 ) where
     M: Msg,
     BS: ActorSend<OMsg = M>,
     E: Encoder<M> + 'static + Send + Clone,
+    E::Error: Send + 'static, // <-- add this line
 {
     let mut addr_to_buff: HashMap<ActorAddr, mpsc::UnboundedSender<M>> = HashMap::new();
     let mut sub_senders = JoinSet::new();
@@ -45,6 +47,7 @@ pub(crate) async fn tx<M, E, BS>(
                     &mut sub_senders,
                     origin,
                     m,
+                    on_send_failure,
                 ),
                 RouteTo::Single(send_to) => send_msg(
                     my_addr,
@@ -55,6 +58,7 @@ pub(crate) async fn tx<M, E, BS>(
                     &mut sub_senders,
                     &send_to,
                     m,
+                    on_send_failure,
                 ),
                 RouteTo::Multiple(receivers) => {
                     let num_receivers = receivers.len();
@@ -71,6 +75,7 @@ pub(crate) async fn tx<M, E, BS>(
                             &mut sub_senders,
                             addr,
                             m.clone(),
+                            on_send_failure,
                         );
                     }
                     send_msg(
@@ -82,6 +87,7 @@ pub(crate) async fn tx<M, E, BS>(
                         &mut sub_senders,
                         &receivers[num_receivers - 1],
                         m,
+                        on_send_failure,
                     );
                 }
             }
@@ -104,12 +110,16 @@ fn send_msg<M, E>(
     sub_senders: &mut JoinSet<()>,
     addr: &str,
     m: M,
+    on_send_failure: SendErrAction,
 ) where
     M: Msg,
     E: Encoder<M> + 'static + Send + Clone,
+    E::Error: Send + 'static,
 {
     if let Some(sender) = addr_to_buff.get(addr) {
-        let _ = sender.send(m);
+        if let Err(e) = sender.send(m) {
+            log::error!("[ACTOR] Failed to send message to {}: {}", addr, e);
+        }
     } else {
         let (tx, rx) = mpsc::unbounded_channel::<M>();
         sub_senders.spawn(sender_task(
@@ -119,6 +129,7 @@ fn send_msg<M, E>(
             rx,
             codec,
             controller_tx,
+            on_send_failure,
         ));
         let _ = tx.send(m);
         addr_to_buff.insert(addr.to_string(), tx);
@@ -132,9 +143,11 @@ async fn sender_task<M, E>(
     rx: mpsc::UnboundedReceiver<M>,
     encoder: E,
     controller_tx: mpsc::Sender<ControlReq>,
+    on_send_failure: SendErrAction,
 ) where
     M: Msg,
     E: Encoder<M> + 'static + Send,
+    E::Error: Send + 'static,
 {
     async fn remote_sender<C: Encoder<M> + 'static + Send, M>(
         my_addr: &'static str,
@@ -142,35 +155,114 @@ async fn sender_task<M, E>(
         mut tx: impl AsyncWrite + Unpin,
         mut rx: mpsc::UnboundedReceiver<M>,
         encoder: C,
-    ) {
+        on_send_failure: SendErrAction,
+    ) where
+        M: Msg,
+    {
         log::info!("[ACTOR] SubTx Started");
         let decoder_name = std::any::type_name::<M>().to_string();
         send_remote_handshake(&mut tx, my_addr, decoder_name, ask_receiver_to_adapt).await;
         let mut framed_writer = FramedWrite::new(tx, encoder);
-        loop {
-            if let Some(msg) = rx.recv().await
-                && framed_writer.send(msg).await.is_err()
-            {
-                break;
+
+        while let Some(msg) = rx.recv().await {
+            match on_send_failure {
+                SendErrAction::Drop => {
+                    if (framed_writer.send(msg).await).is_err() {
+                        log::warn!("[ACTOR] {} Dropping message due to send failure", my_addr);
+                    }
+                }
+                SendErrAction::Retry(retries_opt) => {
+                    let mut attempts = 0;
+                    loop {
+                        if let Some(retries) = retries_opt
+                            && attempts >= retries
+                        {
+                            log::error!("[ACTOR] {} Exhausted retries to send message", my_addr);
+                            break;
+                        }
+
+                        attempts += 1;
+
+                        // Note: here the below clone happens even for successful sends, causing inefficiency
+                        // But how can we know beforehand if the send will succeed or not?
+                        if (framed_writer.send(msg.clone()).await).is_err() {
+                            log::warn!(
+                                "[ACTOR] {} Failed to send message, Retrying {}",
+                                my_addr,
+                                attempts
+                            );
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            continue;
+                        } else {
+                            break;
+                        }
+                    }
+                }
             }
         }
         log::info!("[ACTOR] SubTx Ended");
     }
 
+    /// - `tx`: Channel to the destination actor.
+    /// - `rx`: Internal channel for messages of type `M`, specific to this actor instance.
+    /// - Note: `tx` and `rx` are independent — `rx` collects messages locally between helper functions and
+    ///   `tx` delivers them to the actor. They don’t correlate directly.
     async fn local_sender<M: std::fmt::Debug + Send + 'static + Clone>(
         my_addr: &'static str,
         ask_receiver_to_adapt: bool,
         tx: mpsc::Sender<Box<dyn Any + Send>>,
         mut rx: mpsc::UnboundedReceiver<M>,
+        on_send_failure: SendErrAction,
     ) {
         log::info!("[ACTOR] SubTx Started (Local)");
         let decoder_name = std::any::type_name::<M>().to_string();
         send_local_handshake(&tx, my_addr, decoder_name, ask_receiver_to_adapt).await;
-        loop {
-            if let Some(msg) = rx.recv().await
-                && tx.send(Box::new(msg)).await.is_err()
-            {
-                break;
+        while let Some(msg) = rx.recv().await {
+            // if let Err(e) = tx.send(Box::new(msg)).await {
+            //     log::error!("[ACTOR] Failed to send local message: {}", e);
+            //     break;
+            // }
+            match on_send_failure {
+                SendErrAction::Drop => {
+                    if let Err(e) = tx.send(Box::new(msg)).await {
+                        log::warn!(
+                            "[ACTOR] {} Dropping message due to send failure: {}",
+                            my_addr,
+                            e
+                        );
+                    }
+                }
+                SendErrAction::Retry(retries_opt) => {
+                    let mut attempts = 0;
+                    loop {
+                        if let Some(retries) = retries_opt
+                            && attempts >= retries
+                        {
+                            log::error!(
+                                "[ACTOR] {} Exhausted retries to send local message",
+                                my_addr
+                            );
+                            break;
+                        }
+
+                        attempts += 1;
+
+                        // Note: here the below clone happens even for successful sends, causing inefficiency
+                        // But how can we know beforehand if the send will succeed or not?
+                        if let Err(e) = tx.send(Box::new(msg.clone())).await {
+                            log::warn!(
+                                "[ACTOR] {} Failed to send message, Retrying {}: {}",
+                                my_addr,
+                                attempts,
+                                e
+                            );
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            continue;
+                        } else {
+                            break;
+                        }
+                    }
+                }
             }
         }
         log::info!("[ACTOR] SubTx Ended");
@@ -178,6 +270,7 @@ async fn sender_task<M, E>(
 
     loop {
         let (c_tx, c_rx) = tokio::sync::oneshot::channel();
+        log::debug!("[ACTOR] Sending Resolve request for address: {}", send_addr);
         controller_tx
             .send(ControlReq::Resolve {
                 resp_tx: c_tx,
@@ -201,18 +294,46 @@ async fn sender_task<M, E>(
                     }
                 };
 
-                remote_sender(my_addr, ask_receiver_to_adapt, tx, rx, encoder).await;
+                remote_sender(
+                    my_addr,
+                    ask_receiver_to_adapt,
+                    tx,
+                    rx,
+                    encoder,
+                    on_send_failure,
+                )
+                .await;
                 break;
             }
             Connection::Local(write_half) => {
-                local_sender(my_addr, ask_receiver_to_adapt, write_half, rx).await;
+                local_sender(
+                    my_addr,
+                    ask_receiver_to_adapt,
+                    write_half,
+                    rx,
+                    on_send_failure,
+                )
+                .await;
                 break;
             }
             Connection::CouldntResolve => {
                 log::warn!("[ACTOR] Failed to resolve {}", send_addr);
                 tokio::time::sleep(Duration::from_millis(100)).await;
-                // continue;
-                break;
+                match on_send_failure {
+                    SendErrAction::Drop => break,
+                    SendErrAction::Retry(retries_opt) => {
+                        if let Some(retries) = retries_opt
+                            && retries == 0
+                        {
+                            log::error!(
+                                "[ACTOR] {} Exhausted retries to resolve address {}",
+                                my_addr,
+                                send_addr
+                            );
+                            break;
+                        }
+                    }
+                }
             }
         };
     }

--- a/examples/paxos/src/acceptor.rs
+++ b/examples/paxos/src/acceptor.rs
@@ -5,7 +5,7 @@ use crate::SLEEP_MS;
 use crate::common::{AcceptorAddr, Ballot, PaxosMsg, Val};
 use log::info;
 use reactor_actor::codec::BincodeCodec;
-use reactor_actor::{BehaviourBuilder, RouteTo, RuntimeCtx};
+use reactor_actor::{BehaviourBuilder, RouteTo, RuntimeCtx, SendErrAction};
 
 struct Sender {
     addr: &'static str,
@@ -84,6 +84,10 @@ impl reactor_actor::ActorProcess for Acceptor {
 pub async fn acceptor(ctx: RuntimeCtx) {
     BehaviourBuilder::new(Acceptor::new(ctx.addr), BincodeCodec::default())
         .send(Sender { addr: ctx.addr })
+        .on_send_failure(SendErrAction::Retry {
+            attempts: Some(5),
+            delay_ms: 100,
+        })
         .build()
         .run(ctx)
         .await

--- a/examples/paxos/src/leader.rs
+++ b/examples/paxos/src/leader.rs
@@ -3,7 +3,7 @@ use crate::common::{AcceptorAddr, Ballot, LeaderAddr, PaxosMsg, Val};
 use log::info;
 use rand::random;
 use reactor_actor::codec::BincodeCodec;
-use reactor_actor::{BehaviourBuilder, RouteTo, RuntimeCtx};
+use reactor_actor::{BehaviourBuilder, RouteTo, RuntimeCtx, SendErrAction};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::thread;
@@ -182,6 +182,7 @@ pub async fn actor(ctx: RuntimeCtx, acceptors: Vec<AcceptorAddr>) {
     )
     .send(Sender::new(ctx.addr, acceptors))
     .generator(BallotIterator::new(ctx.addr))
+    .on_send_failure(SendErrAction::Drop) // Retry up to 10 times with 100ms delay
     .build()
     .run(ctx)
     .await

--- a/generic_jctrl/src/main.rs
+++ b/generic_jctrl/src/main.rs
@@ -54,7 +54,9 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reactor_jobm::placement::{CrashOp, MsgLossOp, Probability};
+    use reactor_jobm::placement::{
+        CrashOp, Factor, MsgDelayOp, MsgDuplicationOp, MsgLossOp, Probability,
+    };
     use serde_json::json;
     use std::collections::HashMap;
 
@@ -80,7 +82,9 @@ port = 3000
   actor_name = "pinger"
   other = "ponger"
   chaos.crash = { crash_ms = 10000 }
-  chaos.msg_loss = { start_ms = 10000, probability = 0.1 }
+  chaos.msg_loss = { start_ms = 1000, probability = 0.1 }
+  chaos.msg_duplication = { start_ms = 2000, probability = 0.1, factor = 2 }
+  chaos.msg_delay = { start_ms = 3000, delay_range_ms = [100,200], senders = ["ponger"] }
 
 
   [[placement.ponger]]
@@ -119,12 +123,22 @@ port = 3000
                                 restart_ms: None,
                             }),
                             msg_loss: Some(MsgLossOp {
-                                start_ms: Some(10000),
+                                start_ms: Some(1000),
                                 probability: Probability(0.1),
                                 stop_ms: None,
                             }),
-                            msg_duplication: None,
-                            msg_delay: None,
+                            msg_duplication: Some(MsgDuplicationOp {
+                                start_ms: Some(2000),
+                                probability: Probability(0.1),
+                                factor: Factor(2),
+                                stop_ms: None,
+                            }),
+                            msg_delay: Some(MsgDelayOp {
+                                start_ms: Some(3000),
+                                stop_ms: None,
+                                delay_range_ms: (100, 200),
+                                senders: vec!["ponger".into()],
+                            }),
                         }),
                     }],
                 ),

--- a/generic_jctrl/src/main.rs
+++ b/generic_jctrl/src/main.rs
@@ -79,12 +79,9 @@ port = 3000
   nodename = "node1"
   actor_name = "pinger"
   other = "ponger"
-    [placement.pinger.chaos.crash]
-    crash_ms = 10000
+  chaos.crash = { crash_ms = 10000 }
+  chaos.msg_loss = { start_ms = 10000, probability = 0.1 }
 
-    [placement.pinger.chaos.msg_loss]
-    start_ms = 10000
-    probability = 0.1
 
   [[placement.ponger]]
   nodename = "node1"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -391,7 +391,6 @@ async fn handle_actor_req(
                     .send(Connection::Remote(local.remote_actor_addr))
                     .unwrap();
             } else {
-                warn!("Couldn't Resolve {}", addr);
                 let _ = resp_tx.send(Connection::CouldntResolve);
             }
         }


### PR DESCRIPTION
Notes to resolve:
- [x] Had to add `E::Error: Send + 'static` in multiple places in `actor/src/send.rs` to resolve the error of:
  ```
  <E as tokio_util::codec::Encoder<M>>::Error cannot be sent between threads safely
  ```
  But I'm still not sure what caused this error in the first place.
- [x] For `Retry`, msg gets cloned even for successful sends. Bad for efficiency. 
  - But confused how to resolve, coz how to predict whether the msg send will succeed or not? If send fails, then the initial attempt shouldn't have consumed msg coz now msg cannot be recovered to use in retry.
  - Can use Arc, but unsure of the decision for Arc overhead for every single msg sent.
  - Solved: recover the sent failed msg from Result::Error response
- [x] `Retry` can be extended to also include timeout delay
  - Done.

Other decisions:
- Default choice is `Retry` 5 times with 100 ms delay.
- Callback choice affects both msg send failure and actor resolve failure.

Closes #56